### PR TITLE
fix read-only `gifs` and `math` directories

### DIFF
--- a/Mf-stex
+++ b/Mf-stex
@@ -112,9 +112,11 @@ $(x).mathrun: gifs $(mathfiles)
 
 gifs:
 	(cd $(STEXLIB); tar -cf - gifs) | tar -xpf -
+	chmod u+w gifs
 
 math:
 	(cd $(STEXLIB); tar -cf - math) | tar -xpf -
+	chmod u+w math
 
 $(mathfiles): $(x).hthirdrun $(figps)
 	echo -n gifs= > $(mathfiles)


### PR DESCRIPTION
An installed copy of `stex` might have all write permission bits removed, even for the owner of the installed files: this is the case with [Guix package of `stex`](https://guix.gnu.org/en/packages/stex-1.2.2-1.5405149/), for example. If such an installation is used to initialize the `gifs` or `math` directories (e.g. for an out-of-source build), `tar` likewise creates them without write permissions, preventing subdirectories from being created later. Set the user write bit explicitly to avoid this problem.

There are some flags to `tar` and `cp` that might seem useful, but none of them seem to be portable, even just considering GNU and FreeBSD (as used in Mac OS): thus, `chmod`. In particular, removing `-p` from `tar -xpf -` was not enough to avoid the problem.

Related to https://github.com/racket/racket/pull/4203#issuecomment-1104647744